### PR TITLE
train_array into float32 format

### DIFF
--- a/RUN.md
+++ b/RUN.md
@@ -354,7 +354,7 @@ filesnames = ['a.jpg', 'b.jpg', 'c.jpg']
 d = 20 # feature length
 train_n = 3 # number of images
 work_dir = '/path/to/train_dir'  # temp working directory
-train_array = np.random.rand(train_n,d) # replace this placeholder with your own features
+train_array = np.zeros((train_n, d), dtype='float32')# replace this placeholder with your own features
 
 #export the feature in fastdup readable format
 fastdup.save_binary_feature(work_dir, filenames, train_array)
@@ -365,7 +365,7 @@ fastdup.run(os.path.join(work_dir, 'features.dat.csv'), work_dir=work_dir, d=d, 
 test_filenames = ['d.jpg', 'e.jpg']
 test_n = 2
 test_dir = 'path/to/test_dir'
-test_array = np.random.rand(test_n, d) # replace placeholder this with your own test features
+train_array = np.zeros((train_n, d), dtype='float32') # replace placeholder this with your own test features
 fastdup.save_binary_feature(test_dir, test_filenames, test_array)
 shutil.copy(os.path.join(work_dir, 'nnf.index'), test_dir)
 fastdup.run(os.path.join(work_dir, 'features.dat.csv'), work_dir=test_dir, d=d ,run_mode=4)


### PR DESCRIPTION
AssertionError                            Traceback (most recent call last)
<ipython-input-8-7a804b212bba> in <module>()
     13 #export the feature in fastdup readable format
     14 # fastdup.save
---> 15 fastdup.save_binary_feature(work_dir, img_paths, train_array)
     16 # build the NN model and store it to work_dir/nnf.index
     17 fastdup.run(os.path.join(work_dir, 'features.dat.csv'), work_dir=work_dir, d=d, run_mode=2)

/usr/local/lib/python3.7/dist-packages/fastdup/__init__.py in save_binary_feature(save_path, filenames, np_array)
    334     assert isinstance(filenames[0], str), 'filenames should contain strings with the image absolute paths'
    335     assert isinstance(np_array, np.ndarray),  "np_array should be a numpy array"
--> 336     assert np_array.dtype == 'float32', "np_array dtype must be float32. You can generate the array using the" \
    337                               "command: features = np.zeros((rows, cols), dtype='float32')"
    338     assert np_array.shape[0] == len(filenames), "np_array should contain rows matching to the filenames list"

AssertionError: np_array dtype must be float32. You can generate the array using thecommand: features = np.zeros((rows, cols), dtype='float32')


to avoid this error I change this 
train_array = np.zeros((train_n, d), dtype='float32')# replace this placeholder with your own features